### PR TITLE
Changed the http funtion

### DIFF
--- a/src/import/load.js
+++ b/src/import/load.js
@@ -142,7 +142,9 @@ function http(url, callback) {
   if (!callback) {
     return require('sync-request')('GET', url).getBody();
   }
-  require('request')(url, function(error, response, body) {
+  
+  var options = {url: url, encoding: null, gzip: true};
+  require('request')(options, function(error, response, body) {
     if (!error && response.statusCode === 200) {
       callback(null, body);
     } else {


### PR DESCRIPTION
* Defined gzip to be used by default
* Defined unicode as null by default to avoid wrong references in node.js server

Changes made according the work done to [vega](https://github.com/nyurik/vega/commit/856ce9d78604f6c755566bc82b25b9833789cec9), which is used by [graphoid](https://gerrit.wikimedia.org/r/#/admin/projects/mediawiki/services/graphoid)