### PR TITLE
Parse dates with formats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
  - "0.10"
  - "0.12"
+ - "4.1"
 install: npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: node_js
 node_js:
  - "0.10"
  - "0.12"
- - "4.1"
 install: npm install

--- a/src/import/read.js
+++ b/src/import/read.js
@@ -14,12 +14,22 @@ function parse(data, types) {
 
   types = (types==='auto') ? type.inferAll(data) : util.duplicate(types);
   cols = util.keys(types);
-  parsers = cols.map(function(c) { return type.parsers[types[c]]; });
+  parsers = cols.map(function(c) {
+    if (types[c]) {
+      var a = types[c].split(':', 2);
+      return {
+        parser: type.parsers[a[0]],
+        // optional arguments to be passed to the parser
+        opt: a.length > 1 ? a[1] : null
+      };
+    }
+  });
 
   for (i=0, clen=cols.length; i<len; ++i) {
     d = data[i];
     for (j=0; j<clen; ++j) {
-      d[cols[j]] = parsers[j](d[cols[j]]);
+      var obj = parsers[j];
+      d[cols[j]] = obj.parser(d[cols[j]], obj.opt);
     }
   }
   type.annotation(data, types);

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,6 @@
 var buffer = require('buffer'),
     time = require('./time'),
+    d3_timeF = require('d3-time-format'),
     utc = time.utc;
 
 var u = module.exports = {};
@@ -114,8 +115,10 @@ u.boolean = function(s) {
   return s == null || s === '' ? null : s==='false' ? false : !!s;
 };
 
-u.date = function(s) {
-  return s == null || s === '' ? null : Date.parse(s);
+// parse a date with optional format
+u.date = function(s, format) {
+  var d = format ? d3_timeF.format(format) : Date;
+  return s == null || s === '' ? null : d.parse(s);
 };
 
 u.array = function(x) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,5 @@
 var buffer = require('buffer'),
     time = require('./time'),
-    d3_timeF = require('d3-time-format'),
     utc = time.utc;
 
 var u = module.exports = {};
@@ -115,9 +114,9 @@ u.boolean = function(s) {
   return s == null || s === '' ? null : s==='false' ? false : !!s;
 };
 
-// parse a date with optional format
+// parse a date with optional d3.time-format format
 u.date = function(s, format) {
-  var d = format ? d3_timeF.format(format) : Date;
+  var d = format ? format : Date;
   return s == null || s === '' ? null : d.parse(s);
 };
 

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -1,9 +1,12 @@
 'use strict';
 
+var chai = require('chai');
 var assert = require('chai').assert;
 var util = require('../src/util');
 var read = require('../src/import/read');
 var type = require('../src/import/type');
+
+chai.config.truncateThreshold = 0;
 
 var fs = require('fs');
 var topojson = require('topojson');

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -106,8 +106,9 @@ describe('read', function() {
       assert.equal(null, p.date(null));
     });
     it('should parse date with format', function() {
-      assert.equal(+(new Date(2000, 0, 1)), +p.date('Sun 01/01/2000', '%a %m/%d/%Y'));
-      assert.equal(null, p.date(null, '%a %m/%d/%Y'));
+      assert.equal(+(new Date(1990, 6, 18)), +p.date('18/07/1990', '%d/%m/%Y'));
+      assert.equal(+(new Date(1990, 6, 18)), +p.date('07/18/1990', '%m/%d/%Y'));
+      assert.equal(null, p.date(null, '%d/%m/%Y'));
     });
     it('should parse strings', function() {
       assert.equal('a', p.string('a'));

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -174,17 +174,24 @@ describe('read', function() {
       var json = JSON.stringify({foo: data});
       assert.deepEqual(read(json, {type:'json', property:'foo'}), data);
     });
-    it('should parse date with format', function() {
+
+    it('should parse date with format %d/%m/%Y', function() {
+      var expected = [{foo: new Date(1990, 6, 18)}];
       var json = [{foo: '18/07/1990'}];
-
+      var types = {foo: 'date:%d/%m/%Y'};
+      type.annotation(expected, types);
       assert.deepEqual(
-        read(json, {type:'json', parse: {foo: 'date:%d/%m/%Y'}})[0],
-        {foo: new Date(1990, 6, 18)});
-
-      json = [{foo: '07/18/1990'}];
+        read(json, {type:'json', parse: types}),
+        expected);
+    });
+    it('should parse date with format %m/%d/%Y', function() {
+      var expected = [{foo: new Date(1990, 6, 18)}];
+      var json = [{foo: '07/18/1990'}];
+      var types = {foo: 'date:%m/%d/%Y'};
+      type.annotation(expected, types);
       assert.deepEqual(
-        read(json, {type:'json', parse: {foo: 'date:%m/%d/%Y'}})[0],
-        {foo: new Date(1990, 6, 18)});
+        read(json, {type:'json', parse: types}),
+        expected);
     });
   });
 

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -1,15 +1,15 @@
 'use strict';
 
 var chai = require('chai');
-var assert = require('chai').assert;
+var assert = chai.assert;
 var util = require('../src/util');
 var read = require('../src/import/read');
 var type = require('../src/import/type');
 
-chai.config.truncateThreshold = 0;
-
 var fs = require('fs');
 var topojson = require('topojson');
+
+chai.config.truncateThreshold = 0;
 
 var fields = ['a', 'b', 'c', 'd', 'e'];
 var data = [

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -186,6 +186,15 @@ describe('read', function() {
       assert.deepEqual(
         read(json, {type:'json', parse: types}),
         expected);
+
+      // repeat with single quoted pattern
+      expected = [{foo: new Date(1990, 6, 18)}];
+      json = [{foo: '18.07.1990'}];
+      types = {foo: "date:'%d.%m.%Y'"};
+      type.annotation(expected, types);
+      assert.deepEqual(
+        read(json, {type:'json', parse: types}),
+        expected);
     });
     it('should parse date with format %m.%d.%Y', function() {
       var expected = [{foo: new Date(1990, 6, 18)}];
@@ -195,11 +204,26 @@ describe('read', function() {
       assert.deepEqual(
         read(json, {type:'json', parse: types}),
         expected);
-    });
 
+      // repeat with single quoted pattern
+      expected = [{foo: new Date(1990, 6, 18)}];
+      json = [{foo: '07.18.1990'}];
+      types = {foo: "date:'%m.%d.%Y'"};
+      type.annotation(expected, types);
+      assert.deepEqual(
+        read(json, {type:'json', parse: types}),
+        expected);
+    });
     it('should throw error if format is not escaped', function() {
       var json = [{foo: '18.07.1990'}];
       var types = {foo: 'date:%d.%m.%Y'};
+      assert.throws(function() {
+        read(json, {type:'json', parse: types});
+      });
+    });
+    it('should throw error if format is unrecognized', function() {
+      var json = [{foo: '18.07.1990'}];
+      var types = {foo: 'notAType'};
       assert.throws(function() {
         read(json, {type:'json', parse: types});
       });

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -171,6 +171,18 @@ describe('read', function() {
       var json = JSON.stringify({foo: data});
       assert.deepEqual(read(json, {type:'json', property:'foo'}), data);
     });
+    it('should parse date with format', function() {
+      var json = [{foo: '18/07/1990'}];
+
+      assert.deepEqual(
+        read(json, {type:'json', parse: {foo: 'date:%d/%m/%Y'}})[0],
+        {foo: new Date(1990, 6, 18)});
+
+      json = [{foo: '07/18/1990'}];
+      assert.deepEqual(
+        read(json, {type:'json', parse: {foo: 'date:%m/%d/%Y'}})[0],
+        {foo: new Date(1990, 6, 18)});
+    });
   });
 
   describe('csv', function() {

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -105,6 +105,10 @@ describe('read', function() {
       assert.equal(+(new Date(2000, 0, 1)), +p.date('1/1/2000'));
       assert.equal(null, p.date(null));
     });
+    it('should parse date with format', function() {
+      assert.equal(+(new Date(2000, 0, 1)), +p.date('Sun 01/01/2000', '%a %m/%d/%Y'));
+      assert.equal(null, p.date(null, '%a %m/%d/%Y'));
+    });
     it('should parse strings', function() {
       assert.equal('a', p.string('a'));
       assert.equal('bb', p.string('bb'));

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -8,6 +8,7 @@ var type = require('../src/import/type');
 
 var fs = require('fs');
 var topojson = require('topojson');
+var d3_timeF = require('d3-time-format');
 
 chai.config.truncateThreshold = 0;
 
@@ -109,9 +110,11 @@ describe('read', function() {
       assert.equal(null, p.date(null));
     });
     it('should parse date with format', function() {
-      assert.equal(+(new Date(1990, 6, 18)), +p.date('18/07/1990', '%d/%m/%Y'));
-      assert.equal(+(new Date(1990, 6, 18)), +p.date('07/18/1990', '%m/%d/%Y'));
-      assert.equal(null, p.date(null, '%d/%m/%Y'));
+      assert.equal(+(new Date(1990, 6, 18)),
+        +p.date('18.07.1990', d3_timeF.format('%d.%m.%Y')));
+      assert.equal(+(new Date(1990, 6, 18)),
+        +p.date('07.18.1990', d3_timeF.format('%m.%d.%Y')));
+      assert.equal(null, p.date(null, '%d.%m.%Y'));
     });
     it('should parse strings', function() {
       assert.equal('a', p.string('a'));
@@ -175,23 +178,31 @@ describe('read', function() {
       assert.deepEqual(read(json, {type:'json', property:'foo'}), data);
     });
 
-    it('should parse date with format %d/%m/%Y', function() {
+    it('should parse date with format %d.%m.%Y', function() {
       var expected = [{foo: new Date(1990, 6, 18)}];
-      var json = [{foo: '18/07/1990'}];
-      var types = {foo: 'date:%d/%m/%Y'};
+      var json = [{foo: '18.07.1990'}];
+      var types = {foo: 'date:"%d.%m.%Y"'};
       type.annotation(expected, types);
       assert.deepEqual(
         read(json, {type:'json', parse: types}),
         expected);
     });
-    it('should parse date with format %m/%d/%Y', function() {
+    it('should parse date with format %m.%d.%Y', function() {
       var expected = [{foo: new Date(1990, 6, 18)}];
-      var json = [{foo: '07/18/1990'}];
-      var types = {foo: 'date:%m/%d/%Y'};
+      var json = [{foo: '07.18.1990'}];
+      var types = {foo: 'date:"%m.%d.%Y"'};
       type.annotation(expected, types);
       assert.deepEqual(
         read(json, {type:'json', parse: types}),
         expected);
+    });
+
+    it('should throw error if format is not escaped', function() {
+      var json = [{foo: '18.07.1990'}];
+      var types = {foo: 'date:%d.%m.%Y'};
+      assert.throws(function() {
+        read(json, {type:'json', parse: types});
+      });
     });
   });
 


### PR DESCRIPTION
datalib now supports

```js
dl.read(data, {type: 'json', parse: {'date': 'date:%d.%m.%Y'}});
```