### PR TITLE
Support for array/accessor confidence intervals

### DIFF
--- a/src/stats.js
+++ b/src/stats.js
@@ -435,7 +435,7 @@ stats.z = {};
 // Construct a z-confidence interval at a given significance level
 // Arguments are an array and an optional alpha (defaults to 0.05).
 stats.z.ci = function(values, a, b) {
-  var X = values, alpha = a, f;
+  var X = values, alpha = a;
   if (util.isFunction(a) || util.isString(a)) {
     X = values.map(util.$(a));
     alpha = b;

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -536,21 +536,45 @@ describe('stats', function() {
   });
 
   describe('stats.bootstrap.ci', function() {
+    var g1 = [ {a:1},{a:1}];
     it('should accept an array', function() {
       assert.deepEqual([1,1], stats.bootstrap.ci([1,1]));
     });
+
     it('should accept an array and sample count', function() {
       assert.deepEqual([1,1], stats.bootstrap.ci([1,1], 100));
     });
+
     it('should accept an array, sample count, and alpha', function(){
       assert.deepEqual([1,1], stats.bootstrap.ci([1,1], 100, 0.1));
     });
+
     it('should accept an array, sample count, alpha, and smoothing', function() {
       assert.notEqual(
         stats.bootstrap.ci([1,1], 100, 0.1),
         stats.bootstrap.ci([1,1], 100, 0.1, 5)
       );
     });
+
+    it('should accept an array and accessor',function() {
+      assert.deepEqual([1,1],stats.bootstrap.ci(g1,a));
+    });
+
+    it('should accept an array, accessor, and sample count', function(){
+      assert.deepEqual([1,1],stats.bootstrap.ci(g1,a,100));
+    });
+
+    it('should accept an array, accessor, sample count, and alpha', function(){
+      assert.deepEqual([1,1],stats.bootstrap.ci(g1,a,100,0.1));
+    });
+
+    it('should accept an array, accessor, sample count, alpha, and smoothing', function(){
+      assert.notEqual(
+        stats.bootstrap.ci(g1,a,100,0.1),
+        stats.bootstrap.ci(g1,a,100,0.1,5)
+      );
+    });
+
     it('should ignore invalid values', function() {
       assert.deepEqual([1,1], stats.bootstrap.ci([1,null,1]));
     });
@@ -558,7 +582,9 @@ describe('stats', function() {
 
   describe('stats.z.ci', function() {
     var g1 = [1,2,3,4,5],
-        g2 = [1,1,1];
+        g2 = [1,1,1],
+        g3 = [{a:1},{a:2},{a:3},{a:4},{a:5}],
+        g4 = [{a:1},{a:1},{a:1}];
 
     it('should accept an array', function() {
       assert.deepEqual([1,1], stats.z.ci(g2));
@@ -572,7 +598,19 @@ describe('stats', function() {
       assert.equal(3, stats.z.ci(g1, 1)[0]);
       assert.equal(3, stats.z.ci(g1, 1)[1]);
     });
-
+    
+    it('should accept an array and accessor', function() {
+      assert.deepEqual([1,1], stats.z.ci(g4,a));
+    });
+ 
+    it('should accept an array, accessor, and alpha', function() {
+      assert.ok(
+        stats.z.ci(g3, a)[0] < stats.z.ci(g3, a, 0.1)[0] &&
+        stats.z.ci(g3, a)[1] > stats.z.ci(g3, a, 0.1)[1]
+      );
+      assert.equal(3, stats.z.ci(g3, a, 1)[0]);
+      assert.equal(3, stats.z.ci(g3, a, 1)[1]);
+    });
   });
 
   describe('stats.z.test', function() {

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -556,22 +556,22 @@ describe('stats', function() {
       );
     });
 
-    it('should accept an array and accessor',function() {
-      assert.deepEqual([1,1],stats.bootstrap.ci(g1,a));
+    it('should accept an array and accessor', function() {
+      assert.deepEqual([1,1], stats.bootstrap.ci(g1, a));
     });
 
-    it('should accept an array, accessor, and sample count', function(){
-      assert.deepEqual([1,1],stats.bootstrap.ci(g1,a,100));
+    it('should accept an array, accessor, and sample count', function() {
+      assert.deepEqual([1,1], stats.bootstrap.ci(g1, a, 100));
     });
 
-    it('should accept an array, accessor, sample count, and alpha', function(){
-      assert.deepEqual([1,1],stats.bootstrap.ci(g1,a,100,0.1));
+    it('should accept an array, accessor, sample count, and alpha', function() {
+      assert.deepEqual([1,1], stats.bootstrap.ci(g1, a, 100, 0.1));
     });
 
-    it('should accept an array, accessor, sample count, alpha, and smoothing', function(){
+    it('should accept an array, accessor, sample count, alpha, and smoothing', function() {
       assert.notEqual(
-        stats.bootstrap.ci(g1,a,100,0.1),
-        stats.bootstrap.ci(g1,a,100,0.1,5)
+        stats.bootstrap.ci(g1, a, 100, 0.1),
+        stats.bootstrap.ci(g1, a, 100, 0.1, 5)
       );
     });
 
@@ -598,11 +598,11 @@ describe('stats', function() {
       assert.equal(3, stats.z.ci(g1, 1)[0]);
       assert.equal(3, stats.z.ci(g1, 1)[1]);
     });
-    
+
     it('should accept an array and accessor', function() {
       assert.deepEqual([1,1], stats.z.ci(g4,a));
     });
- 
+
     it('should accept an array, accessor, and alpha', function() {
       assert.ok(
         stats.z.ci(g3, a)[0] < stats.z.ci(g3, a, 0.1)[0] &&
@@ -614,14 +614,23 @@ describe('stats', function() {
   });
 
   describe('stats.z.test', function() {
-    var g1 = [1,2,3,4,5];
+    var g1 = [1,2,3,4,5],
+        g2 = [{a:1},{a:2},{a:3},{a:4},{a:5}];
 
     it('should accept an array', function() {
-      assert.ok(stats.z.test(g1, 0) < 0.05);
+      assert.ok(stats.z.test(g1) < 0.05);
+    });
+
+    it('should accept an array and an accessor', function() {
+      assert.ok(stats.z.test(g2, a) < 0.05);
     });
 
     it('should accept an array and a null hypothesis', function() {
       assert.equal(1, stats.z.test(g1, {nullh:3}));
+    });
+
+    it('should accept an array, an accessor, and a null hypothesis', function() {
+      assert.equal(1, stats.z.test(g2, a, {nullh:3}));
     });
 
     it('should degrade gracefully if there is no variation', function() {


### PR DESCRIPTION
Allows confidence intervals to be build with an an array of objects and an accessor rather than just an array of objects.