### PR TITLE
Compile accessor functions

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -122,15 +122,12 @@ u.array = function(x) {
 
 u.str = function(x) {
   return u.isArray(x) ? '[' + x.map(u.str) + ']'
-    : u.isObject(x) ? JSON.stringify(x)
-    : u.isString(x) ? ('\''+util_escape_str(x)+'\'') : x;
+    : u.isObject(x) || u.isString(x) ?
+      // Output valid JSON and JS source strings.
+      // See http://timelessrepo.com/json-isnt-a-javascript-subset
+      JSON.stringify(x).replace('\u2028','\\u2028').replace('\u2029', '\\u2029')
+    : x;
 };
-
-var escape_str_re = /(^|[^\\])'/g;
-
-function util_escape_str(x) {
-  return x.replace(escape_str_re, '$1\\\'');
-}
 
 // data access functions
 
@@ -146,7 +143,7 @@ u.field = function(f) {
 
 u.accessor = function(f) {
   return f==null || u.isFunction(f) ? f :
-    u.namedfunc(f, Function('x', 'return x[' + u.field(f).map(u.str).join('][') + ']'));
+    u.namedfunc(f, Function('x', 'return x[' + u.field(f).map(JSON.stringify).join('][') + ']'));
 }
 
 // short-cut for accessor

--- a/src/util.js
+++ b/src/util.js
@@ -145,13 +145,9 @@ u.field = function(f) {
 };
 
 u.accessor = function(f) {
-  var s;
   return f==null || u.isFunction(f) ? f :
-    u.namedfunc(f, (s = u.field(f)).length > 1 ?
-      function(x) { return s.reduce(function(x,f) { return x[f]; }, x); } :
-      function(x) { return x[f]; }
-    );
-};
+    u.namedfunc(f, Function('x', 'return x[' + u.field(f).map(u.str).join('][') + ']'));
+}
 
 // short-cut for accessor
 u.$ = u.accessor;

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -240,12 +240,12 @@ describe('util', function() {
   });
 
   describe('str', function() {
-    it('should wrap string arguments in single quotation marks', function() {
-      assert.strictEqual(util.str('test'), "'test'");
+    it('should wrap string arguments in double quotation marks', function() {
+      assert.strictEqual(util.str('test'), '"test"');
     });
 
     it('should wrap arrays in square brackets', function() {
-      assert.equal(util.str(['1', '2']), "['1','2']");
+      assert.equal(util.str(['1', '2']), '["1","2"]');
     });
 
     it('should return boolean arguments as they are', function() {
@@ -260,12 +260,30 @@ describe('util', function() {
     });
 
     it('should recursively wrap arrays in square brackets', function() {
-      assert.equal(util.str([['1', 3], '2']), "[['1',3],'2']");
+      assert.equal(util.str([['1', 3], '2']), '[["1",3],"2"]');
     });
 
     it('should stringify objects', function() {
       var x = {a: {b: {c: 1}}};
       assert.equal(JSON.stringify(x), util.str(x));
+    });
+
+    it('should handle quotes in strings', function() {
+      var tests = ["'hello'", '"hello"', ];
+      tests.forEach(function(s) {
+        assert.equal(s, (1,eval)(util.str(s)));
+      });
+    });
+
+    it('should handle special characters in strings', function() {
+      var tests = ["\ntest", // newline
+        '\u0000',
+        '\u2028', // line separator
+        '\u2029' // paragraph separator
+      ];
+      tests.forEach(function(s) {
+        assert.equal(s, (1,eval)(util.str(s)));
+      });
     });
   });
 


### PR DESCRIPTION
http://jsperf.com/datalib-accessors

It seems that compiling the accessor functions using Function is faster than using reduce for the multiple field case, and is at least as fast for the single field case.