### PR TITLE
dl.comparator should account for null values

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -194,8 +194,9 @@ u.comparator = function(sort) {
     var i, n, f, x, y;
     for (i=0, n=sort.length; i<n; ++i) {
       f = sort[i]; x = f(a); y = f(b);
-      if (x < y) return -1 * sign[i];
-      if (x > y) return sign[i];
+      if (x == null && y == null) return 0;
+      if (x < y || x == null) return -1 * sign[i];
+      if (x > y || y == null) return sign[i];
     }
     return 0;
   };


### PR DESCRIPTION
`dl.comparator` does not currently account for null values resulting in some odd sort orders (vega/vega#584). With this PR, `dl.comparator` considers null values to be "low" and thus sorts them to the head or tail of the array.