### PR TITLE
Remove browserify-versionify to fix webpack/browserify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "devDependencies": {
     "browserify": "^12.0.1",
-    "browserify-versionify": "^1.0.6",
     "chai": "^3.4.1",
     "istanbul": "latest",
     "jshint": "^2.9.1-rc1",
@@ -57,11 +56,6 @@
     "cover": "TZ=America/Los_Angeles istanbul cover _mocha -- --recursive test/",
     "build": "browserify src/index.js -d -s dl -o datalib.js",
     "postbuild": "uglifyjs datalib.js -c -m -o datalib.min.js"
-  },
-  "browserify": {
-    "transform": [
-      "browserify-versionify"
-    ]
   },
   "browser": {
     "buffer": false,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 var util = require('./util');
 
 var dl = {
-  version:    '__VERSION__',
+  version:    require('../package.json').version,
   load:       require('./import/load'),
   read:       require('./import/read'),
   type:       require('./import/type'),


### PR DESCRIPTION
This pulls the version directly from package.json and removes the need for a transform to enable better compatibility with build tools like browserify and webpack. Note webpack users will still need to have the json-loader enabled.

This same change was just made to vega-lite via vega/vega-lite#1575 and is related to vega/vega#369