### PR TITLE
Optionally ignore certain values when inferring types

### DIFF
--- a/src/import/type.js
+++ b/src/import/type.js
@@ -44,7 +44,7 @@ function type(values, f) {
   for (i=0, n=values.length; !util.isValid(v) && i<n; ++i) {
     v = f ? f(values[i]) : values[i];
   }
- 
+
   return util.isDate(v) ? 'date' :
     util.isNumber(v)    ? 'number' :
     util.isBoolean(v)   ? 'boolean' :
@@ -72,7 +72,7 @@ function infer(values, f, ignore) {
     v = f ? f(values[i]) : values[i];
     // test value against remaining types
     for (j=0; j<types.length; ++j) {
-      if ((!ignore || ignore.test(v)) && util.isValid(v) && !TESTS[types[j]](v)) {
+      if ((!ignore || !ignore.test(v)) && util.isValid(v) && !TESTS[types[j]](v)) {
         types.splice(j, 1);
         j -= 1;
       }

--- a/src/import/type.js
+++ b/src/import/type.js
@@ -44,7 +44,7 @@ function type(values, f) {
   for (i=0, n=values.length; !util.isValid(v) && i<n; ++i) {
     v = f ? f(values[i]) : values[i];
   }
-
+ 
   return util.isDate(v) ? 'date' :
     util.isNumber(v)    ? 'number' :
     util.isBoolean(v)   ? 'boolean' :
@@ -59,7 +59,7 @@ function typeAll(data, fields) {
   }, {});
 }
 
-function infer(values, f) {
+function infer(values, f, ignore) {
   values = util.array(values);
   f = util.$(f);
   var i, j, v;
@@ -72,7 +72,7 @@ function infer(values, f) {
     v = f ? f(values[i]) : values[i];
     // test value against remaining types
     for (j=0; j<types.length; ++j) {
-      if (util.isValid(v) && !TESTS[types[j]](v)) {
+      if ((!ignore || ignore.test(v)) && util.isValid(v) && !TESTS[types[j]](v)) {
         types.splice(j, 1);
         j -= 1;
       }
@@ -84,10 +84,10 @@ function infer(values, f) {
   return types[0];
 }
 
-function inferAll(data, fields) {
+function inferAll(data, fields, ignore) {
   var get = fields ? util.identity : (fields = fieldNames(data[0]), bracket);
   return fields.reduce(function(types, f) {
-    types[f] = infer(data, get(f));
+    types[f] = infer(data, get(f), ignore);
     return types;
   }, {});
 }


### PR DESCRIPTION
The type inference got messed up by some "?" values in a dataset. Being able to (optionally) pass a regex to infer / inferAll and thus ignore certain values can solve problems like this. 

Example 
```
// Ignore any sequence of "?" entries
let typesIgnore = datalib.type.inferAll(data, data.columns, /^[ ?]*[?][ ?]*$/);
// Ignore nothing
let types = datalib.type.inferAll(data, data.columns);

```

Results: 
![screen shot 2017-06-10 at 2 54 20 pm](https://user-images.githubusercontent.com/11595637/27002902-ce3807ec-4dec-11e7-807e-b107ee090a54.png)
