### PR TITLE
Skew

### DIFF
--- a/src/stats.js
+++ b/src/stats.js
@@ -176,12 +176,39 @@ stats.stdev = function(values, f) {
   return Math.sqrt(stats.variance(values, f));
 };
 
-// Compute the Pearson mode skewness ((median-mean)/stdev) of an array of numbers.
-stats.modeskew = function(values, f) {
+
+// DEPRECATED reference to original modeskew function.
+stats.modeskew = function(values, f){
+  return stats.npskew(values, f);
+};
+
+// Compute the non-parametric skewness ((mean-med)/stdev) of an array of numbers.
+stats.npskew = function(values, f) {
   var avg = stats.mean(values, f),
       med = stats.median(values, f),
       std = stats.stdev(values, f);
   return std === 0 ? 0 : (avg - med) / std;
+};
+
+//Compute the sample skewness
+stats.skew = function(values, f) {
+  var avg = stats.mean(values, f),
+      std = stats.stdev(values, f),
+      sampleFactor,
+      moment = 0, delta, i, n, c, v;
+
+  //compute sample third central moment
+  for (i=0, c=0, n=values.length; i<n; ++i) {
+    v = f ? util.$(f)(values[i]) : values[i];
+    if (util.isValid(v)) {
+      delta = Math.pow(v - avg, 3) - moment;
+      moment = moment + delta / (++c);
+    }
+  }
+
+  //convert to symmetric unbiased estimators
+  sampleFactor = (n * n) / ((n - 1) * (n - 2));
+  return std && n > 2 ? sampleFactor * moment / Math.pow(std, 3) : 0;
 };
 
 // Find the minimum value in an array.

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -312,7 +312,7 @@ describe('stats', function() {
     });
   });
 
-  describe('modeskew', function() {
+  describe('npskew', function() {
     it('should calculate modeskew values', function() {
       assert.equal(stats.modeskew([]), 0);
       assert.equal(stats.modeskew([1]), 0);
@@ -325,6 +325,25 @@ describe('stats', function() {
       assert.equal(stats.modeskew([{a:1}, {a:1} ,{a:4}], 'a'), 1/Math.sqrt(3));
     });
   });
+
+  describe('skew', function() {
+    it('should calculate skew values', function() {
+      assert.equal(stats.skew([]), 0);
+      assert.equal(stats.skew([1]), 0);
+      assert.equal(stats.skew([1,3]), 0);
+      assert.closeTo(Math.sqrt(3), stats.skew([1,1,4]), EPSILON);
+    });
+
+    it('should support accessor', function() {
+      assert.equal(stats.skew([{a:1}, {a:2}], 'a'), 0);
+      assert.closeTo(Math.sqrt(3), stats.skew([{a:1}, {a:1} ,{a:4}], 'a'), EPSILON);
+    });
+
+    it('should ignore invalid values', function() {
+      assert.equal(stats.skew([1,3,NaN]), 0);
+    });
+  });
+
 
   describe('rank', function() {
     it('should calculate rank values', function() {

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -314,15 +314,15 @@ describe('stats', function() {
 
   describe('npskew', function() {
     it('should calculate modeskew values', function() {
-      assert.equal(stats.modeskew([]), 0);
-      assert.equal(stats.modeskew([1]), 0);
-      assert.equal(stats.modeskew([1,3]), 0);
-      assert.equal(stats.modeskew([1,1,4]), 1/Math.sqrt(3));
+      assert.equal(stats.npskew([]), 0);
+      assert.equal(stats.npskew([1]), 0);
+      assert.equal(stats.npskew([1,3]), 0);
+      assert.equal(stats.npskew([1,1,4]), 1/Math.sqrt(3));
     });
 
     it('should support accessor', function() {
-      assert.equal(stats.modeskew([{a:1}, {a:2}], 'a'), 0);
-      assert.equal(stats.modeskew([{a:1}, {a:1} ,{a:4}], 'a'), 1/Math.sqrt(3));
+      assert.equal(stats.npskew([{a:1}, {a:2}], 'a'), 0);
+      assert.equal(stats.npskew([{a:1}, {a:1} ,{a:4}], 'a'), 1/Math.sqrt(3));
     });
   });
 


### PR DESCRIPTION
Added `skew` function that is based on the sample skew functions provided by Excel and suggested by Wikipedia.

Old `modeskew` function now points to `npskew` for "non-parametric skew" as a stepping stone for deprecation. I did not update the `profile` or `summary` methods (which manually calculate non-parametric skew but call it `modeskew`), since I'm not certain what the deprecation plan is.