### PR TITLE
Fix check and avoid collision with globals due to a typo in `isString()`

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -75,7 +75,7 @@ u.isFunction = function(obj) {
 };
 
 u.isString = function(obj) {
-  return typeof value === 'string' || toString.call(obj) === '[object String]';
+  return typeof obj === 'string' || toString.call(obj) === '[object String]';
 };
 
 u.isArray = Array.isArray || function(obj) {


### PR DESCRIPTION
Detected in a downstream MediaWiki extension and reported in their bug tracker [here](https://phabricator.wikimedia.org/T304028). Thanks to Lucas Werkmeister for locating the offending upstream method.